### PR TITLE
Fix Namespace Selector Error Propagation and Scope Policy for Accurat…

### DIFF
--- a/api/kyverno/v1/spec_types.go
+++ b/api/kyverno/v1/spec_types.go
@@ -311,6 +311,10 @@ func (s *Spec) GetApplyRules() ApplyRulesType {
 	return *s.ApplyRules
 }
 
+func (s *Spec) GetRules() []Rule {
+	return s.Rules
+}
+
 // ValidateRuleNames checks if the rule names are unique across a policy
 func (s *Spec) ValidateRuleNames(path *field.Path) (errs field.ErrorList) {
 	names := sets.New[string]()

--- a/pkg/background/generate/controller.go
+++ b/pkg/background/generate/controller.go
@@ -214,7 +214,11 @@ func (c *GenerateController) applyGenerate(trigger unstructured.Unstructured, ur
 		return nil, nil
 	}
 
-	namespaceLabels := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), c.nsLister, logger)
+	namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), c.nsLister, []kyvernov1.PolicyInterface{p}, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	policyContext, err := common.NewBackgroundContext(logger, c.client, ur.Spec.Context, p, &trigger, c.configuration, c.jp, namespaceLabels)
 	if err != nil {
 		return nil, err

--- a/pkg/background/mutate/mutate.go
+++ b/pkg/background/mutate/mutate.go
@@ -148,7 +148,13 @@ func (c *mutateExistingController) ProcessUR(ur *kyvernov2.UpdateRequest) error 
 			}
 		}
 
-		namespaceLabels := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), c.nsLister, logger)
+		namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), c.nsLister, []kyvernov1.PolicyInterface{policy}, logger)
+		if err != nil {
+			logger.WithName(rule.Name).Error(err, "failed to get namespace labels")
+			errs = append(errs, err)
+			continue
+		}
+
 		policyContext, err := common.NewBackgroundContext(logger, c.client, ur.Spec.Context, policy, trigger, c.configuration, c.jp, namespaceLabels)
 		if err != nil {
 			logger.WithName(rule.Name).Error(err, "failed to build policy context")

--- a/pkg/policy/generate.go
+++ b/pkg/policy/generate.go
@@ -105,7 +105,11 @@ func (pc *policyController) handleGenerateForExisting(policy kyvernov1.PolicyInt
 		triggers = getTriggers(pc.client, rule, policy.IsNamespaced(), policy.GetNamespace(), pc.log)
 		policyNew.GetSpec().SetRules([]kyvernov1.Rule{rule})
 		for _, trigger := range triggers {
-			namespaceLabels := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), pc.nsLister, pc.log)
+			namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(trigger.GetKind(), trigger.GetNamespace(), pc.nsLister, []kyvernov1.PolicyInterface{policyNew}, pc.log)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("failed to get namespace labels for rule %s: %w", rule.Name, err))
+				continue
+			}
 			policyContext, err := common.NewBackgroundContext(pc.log, pc.client, ur.Spec.Context, policy, trigger, pc.configuration, pc.jp, namespaceLabels)
 			if err != nil {
 				errors = append(errors, fmt.Errorf("failed to build policy context for rule %s: %w", rule.Name, err))

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -399,7 +399,11 @@ func (pc *policyController) requeuePolicies() {
 }
 
 func (pc *policyController) handleUpdateRequest(ur *kyvernov2.UpdateRequest, triggerResource *unstructured.Unstructured, ruleName string, policy kyvernov1.PolicyInterface) (skip bool, err error) {
-	namespaceLabels := engineutils.GetNamespaceSelectorsFromNamespaceLister(triggerResource.GetKind(), triggerResource.GetNamespace(), pc.nsLister, pc.log)
+	namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(triggerResource.GetKind(), triggerResource.GetNamespace(), pc.nsLister, []kyvernov1.PolicyInterface{policy}, pc.log)
+	if err != nil {
+		return false, fmt.Errorf("failed to get namespace labels for rule %s: %w", ruleName, err)
+	}
+
 	policyContext, err := backgroundcommon.NewBackgroundContext(pc.log, pc.client, ur.Spec.Context, policy, triggerResource, pc.configuration, pc.jp, namespaceLabels)
 	if err != nil {
 		return false, fmt.Errorf("failed to build policy context for rule %s: %w", ruleName, err)

--- a/pkg/utils/engine/labels.go
+++ b/pkg/utils/engine/labels.go
@@ -1,21 +1,85 @@
 package engine
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/logging"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // GetNamespaceSelectorsFromNamespaceLister - extract the namespacelabels when namespace lister is passed
-func GetNamespaceSelectorsFromNamespaceLister(kind, namespaceOfResource string, nsLister corev1listers.NamespaceLister, logger logr.Logger) map[string]string {
+func GetNamespaceSelectorsFromNamespaceLister(kind, namespaceOfResource string, nsLister corev1listers.NamespaceLister, policies []kyvernov1.PolicyInterface, logger logr.Logger) (map[string]string, error) {
 	namespaceLabels := make(map[string]string)
+	if !hasNamespaceSelector(policies) {
+		return namespaceLabels, nil
+	}
+
 	if kind != "Namespace" && namespaceOfResource != "" {
 		namespaceObj, err := nsLister.Get(namespaceOfResource)
 		if err != nil {
 			logging.Error(err, "failed to get the namespace", "name", namespaceOfResource)
-			return namespaceLabels
+			return namespaceLabels, err
 		}
-		return namespaceObj.DeepCopy().GetLabels()
+
+		// Check if the namespace object is nil (namespace not found)
+		if namespaceObj == nil {
+			err := fmt.Errorf("namespace %s not found", namespaceOfResource)
+			logging.Error(err, "namespace object is nil", "name", namespaceOfResource)
+			return namespaceLabels, err
+		}
+
+		return namespaceObj.DeepCopy().GetLabels(), nil
 	}
-	return namespaceLabels
+
+	return namespaceLabels, nil
+}
+
+func hasNamespaceSelector(policies []kyvernov1.PolicyInterface) bool {
+	for _, policy := range policies {
+		spec := policy.GetSpec()
+		if spec == nil {
+			continue
+		}
+
+		rules := spec.GetRules()
+		for _, rule := range rules {
+			if rule.MatchResources.ResourceDescription.NamespaceSelector != nil {
+				return true
+			}
+
+			if rule.ExcludeResources != nil && rule.ExcludeResources.ResourceDescription.NamespaceSelector != nil {
+				return true
+			}
+
+			for _, ele := range rule.MatchResources.All {
+				if ele.ResourceDescription.NamespaceSelector != nil {
+					return true
+				}
+			}
+
+			for _, ele := range rule.MatchResources.Any {
+				if ele.ResourceDescription.NamespaceSelector != nil {
+					return true
+				}
+			}
+
+			if rule.ExcludeResources != nil {
+				for _, ele := range rule.ExcludeResources.All {
+					if ele.ResourceDescription.NamespaceSelector != nil {
+						return true
+					}
+				}
+
+				for _, ele := range rule.ExcludeResources.Any {
+					if ele.ResourceDescription.NamespaceSelector != nil {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/utils/engine/labels_test.go
+++ b/pkg/utils/engine/labels_test.go
@@ -1,0 +1,581 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// mockNamespaceLister is a mock implementation of the corev1listers.NamespaceLister interface.
+type mockNamespaceLister struct {
+	namespaces map[string]*corev1.Namespace
+	err        error
+}
+
+func (m *mockNamespaceLister) Get(name string) (*corev1.Namespace, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if ns, ok := m.namespaces[name]; ok {
+		return ns, nil
+	}
+	return nil, nil
+}
+
+func (m *mockNamespaceLister) List(selector labels.Selector) ([]*corev1.Namespace, error) {
+	var nsList []*corev1.Namespace
+	for _, ns := range m.namespaces {
+		if selector.Matches(labels.Set(ns.Labels)) {
+			nsList = append(nsList, ns)
+		}
+	}
+	return nsList, nil
+}
+
+func TestHasNamespaceSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []kyvernov1.PolicyInterface
+		want     bool
+	}{
+		{
+			name:     "no policies",
+			policies: []kyvernov1.PolicyInterface{},
+			want:     false,
+		},
+		{
+			name: "namespace selector in MatchResources",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{"env": "prod"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "namespace selector in ExcludeResources.ResourceDescription",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								ExcludeResources: &kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{"env": "dev"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "namespace selector in MatchResources.All slice",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									All: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{
+													MatchLabels: map[string]string{"foo": "bar"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "namespace selector in MatchResources.Any slice",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									Any: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{
+													MatchLabels: map[string]string{"key": "value"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "namespace selector in ExcludeResources.All slice",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								ExcludeResources: &kyvernov1.MatchResources{
+									All: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{
+													MatchLabels: map[string]string{"exclude": "all"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "namespace selector in ExcludeResources.Any slice",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								ExcludeResources: &kyvernov1.MatchResources{
+									Any: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{
+													MatchLabels: map[string]string{"exclude": "any"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "policy with no namespace selector anywhere",
+			policies: []kyvernov1.PolicyInterface{
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										Kinds: []string{"Pod"},
+									},
+								},
+								ExcludeResources: &kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										Kinds: []string{"Deployment"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasNamespaceSelector(tt.policies)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetNamespaceSelectorsFromNamespaceLister(t *testing.T) {
+	tests := []struct {
+		name                string
+		kind                string
+		namespaceOfResource string
+		nsLister            corev1listers.NamespaceLister
+		policies            []kyvernov1.PolicyInterface
+		wantLabels          map[string]string
+		wantErr             bool
+	}{
+		{
+			name:                "no namespace selector in policies returns empty map",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"env": "prod"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with no namespace selector.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										Kinds: []string{"Pod"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{},
+			wantErr:    false,
+		},
+		{
+			name:                "resource kind Namespace bypass lookup",
+			kind:                "Namespace",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"env": "prod"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy defines a namespace selector, but kind is "Namespace" so lookup is skipped.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{},
+			wantErr:    false,
+		},
+		{
+			name:                "empty namespace returns empty map",
+			kind:                "Pod",
+			namespaceOfResource: "",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"env": "prod"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy has a namespace selector but namespaceOfResource is empty.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{},
+			wantErr:    false,
+		},
+		{
+			name:                "lister returns error",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				err: errors.New("lookup failure"),
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy requires namespace selector.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{},
+			wantErr:    true,
+		},
+		{
+			name:                "namespace not found (nil object returned)",
+			kind:                "Pod",
+			namespaceOfResource: "nonexistent",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{}, // lookup returns nil
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy requires namespace selector.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{},
+			wantErr:    true,
+		},
+		{
+			name:                "successful lookup from MatchResources",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"env": "prod", "tier": "frontend"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with namespace selector in MatchResources.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									ResourceDescription: kyvernov1.ResourceDescription{
+										NamespaceSelector: &metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{"env": "prod", "tier": "frontend"},
+			wantErr:    false,
+		},
+		{
+			name:                "successful lookup from MatchResources.All slice",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "myapp", "team": "devops"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with namespace selector in MatchResources.All.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									All: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{"app": "myapp", "team": "devops"},
+			wantErr:    false,
+		},
+		{
+			name:                "successful lookup from MatchResources.Any slice",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"role": "backend", "zone": "us-east"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with namespace selector in MatchResources.Any.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								MatchResources: kyvernov1.MatchResources{
+									Any: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{"role": "backend", "zone": "us-east"},
+			wantErr:    false,
+		},
+		{
+			name:                "successful lookup from ExcludeResources.All slice",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"exclude": "all", "region": "east"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with namespace selector in ExcludeResources.All.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								ExcludeResources: &kyvernov1.MatchResources{
+									All: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{"exclude": "all", "region": "east"},
+			wantErr:    false,
+		},
+		{
+			name:                "successful lookup from ExcludeResources.Any slice",
+			kind:                "Pod",
+			namespaceOfResource: "default",
+			nsLister: &mockNamespaceLister{
+				namespaces: map[string]*corev1.Namespace{
+					"default": {
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"exclude": "any", "cluster": "main"},
+						},
+					},
+				},
+			},
+			policies: []kyvernov1.PolicyInterface{
+				// Policy with namespace selector in ExcludeResources.Any.
+				&kyvernov1.ClusterPolicy{
+					Spec: kyvernov1.Spec{
+						Rules: []kyvernov1.Rule{
+							{
+								ExcludeResources: &kyvernov1.MatchResources{
+									Any: []kyvernov1.ResourceFilter{
+										{
+											ResourceDescription: kyvernov1.ResourceDescription{
+												NamespaceSelector: &metav1.LabelSelector{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{"exclude": "any", "cluster": "main"},
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetNamespaceSelectorsFromNamespaceLister(
+				tt.kind,
+				tt.namespaceOfResource,
+				tt.nsLister,
+				tt.policies,
+				logging.GlobalLogger(),
+			)
+			if tt.wantErr {
+				assert.Error(t, err, "expected error but got nil")
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
+			}
+			assert.Equal(t, tt.wantLabels, got)
+		})
+	}
+}

--- a/pkg/webhooks/resource/generation/handler.go
+++ b/pkg/webhooks/resource/generation/handler.go
@@ -121,7 +121,12 @@ func (h *generationHandler) handleTrigger(
 		var appliedRules, failedRules []engineapi.RuleResponse
 		policyContext := policyContext.WithPolicy(policy)
 		if request.Kind.Kind != "Namespace" && request.Namespace != "" {
-			policyContext = policyContext.WithNamespaceLabels(utils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, h.log))
+			namespaceLabels, err := utils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, []kyvernov1.PolicyInterface{policy}, h.log)
+			if err != nil {
+				h.log.Error(err, "failed to get namespace labels for policy", "policy", policy.GetName())
+				continue
+			}
+			policyContext = policyContext.WithNamespaceLabels(namespaceLabels)
 		}
 		engineResponse := h.engine.ApplyBackgroundChecks(ctx, policyContext)
 		for _, rule := range engineResponse.PolicyResponse.Rules {

--- a/pkg/webhooks/resource/imageverification/handler.go
+++ b/pkg/webhooks/resource/imageverification/handler.go
@@ -110,7 +110,12 @@ func (h *imageVerificationHandler) handleVerifyImages(
 
 				policyContext := policyContext.WithPolicy(policy)
 				if request.Kind.Kind != "Namespace" && request.Namespace != "" {
-					policyContext = policyContext.WithNamespaceLabels(engineutils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, h.log))
+					namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, []kyvernov1.PolicyInterface{policy}, h.log)
+					if err != nil {
+						h.log.Error(err, "failed to get namespace labels for policy", "policy", policy.GetName())
+						return
+					}
+					policyContext = policyContext.WithNamespaceLabels(namespaceLabels)
 				}
 
 				resp, ivm := h.engine.VerifyAndPatchImages(ctx, policyContext)

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -124,7 +124,7 @@ func (v *mutationHandler) applyMutations(
 					failurePolicy = kyvernov1.Fail
 				}
 
-				engineResponse, policyPatches, err := v.applyMutation(ctx, request.AdmissionRequest, currentContext, failurePolicy)
+				engineResponse, policyPatches, err := v.applyMutation(ctx, request.AdmissionRequest, currentContext, failurePolicy, policy)
 				if err != nil {
 					return fmt.Errorf("mutation policy %s error: %v", policy.GetName(), err)
 				}
@@ -172,9 +172,14 @@ func (v *mutationHandler) applyMutations(
 	return jsonutils.JoinPatches(patch.ConvertPatches(patches...)...), engineResponses, nil
 }
 
-func (h *mutationHandler) applyMutation(ctx context.Context, request admissionv1.AdmissionRequest, policyContext *engine.PolicyContext, failurePolicy kyvernov1.FailurePolicyType) (*engineapi.EngineResponse, []jsonpatch.JsonPatchOperation, error) {
+func (h *mutationHandler) applyMutation(ctx context.Context, request admissionv1.AdmissionRequest, policyContext *engine.PolicyContext, failurePolicy kyvernov1.FailurePolicyType, policy kyvernov1.PolicyInterface) (*engineapi.EngineResponse, []jsonpatch.JsonPatchOperation, error) {
 	if request.Kind.Kind != "Namespace" && request.Namespace != "" {
-		policyContext = policyContext.WithNamespaceLabels(engineutils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, h.log))
+		namespaceLabels, err := engineutils.GetNamespaceSelectorsFromNamespaceLister(request.Kind.Kind, request.Namespace, h.nsLister, []kyvernov1.PolicyInterface{policy}, h.log)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		policyContext = policyContext.WithNamespaceLabels(namespaceLabels)
 	}
 
 	engineResponse := h.engine.Mutate(ctx, policyContext)

--- a/pkg/webhooks/resource/updaterequest.go
+++ b/pkg/webhooks/resource/updaterequest.go
@@ -30,7 +30,7 @@ func (h *resourceHandlers) handleMutateExisting(ctx context.Context, logger logr
 		defer wg.Done()
 	}
 
-	policyContext, err := h.buildPolicyContextFromAdmissionRequest(logger, request)
+	policyContext, err := h.buildPolicyContextFromAdmissionRequest(logger, request, policies)
 	if err != nil {
 		logger.Error(err, "failed to create policy context")
 		return
@@ -100,7 +100,7 @@ func (h *resourceHandlers) handleGenerate(ctx context.Context, logger logr.Logge
 		defer wg.Done()
 	}
 
-	policyContext, err := h.buildPolicyContextFromAdmissionRequest(logger, request)
+	policyContext, err := h.buildPolicyContextFromAdmissionRequest(logger, request, generatePolicies)
 	if err != nil {
 		logger.Error(err, "failed to create policy context")
 		return


### PR DESCRIPTION
…e Rule Evaluation (#12744)

* getRules function defined in the spec_types



* has namespace selector logic defined in the labels



* HasNamespaceSelector logic integrated with the getNamespaceSelectorsFromNamespaceLister



* added nil check for the namespace object



* labels file test cases added



* background package updated with the modified signature of the namespace sleector



* use policyNew in GetNamespaceSelectorsFromNamespaceLister to scope evaluation to current rule

In handleGenerateForExisting, we build policyNew to include only the currently evaluated rule. Updated the call to GetNamespaceSelectorsFromNamespaceLister to use policyNew instead of the full policy to ensure the namespaceSelector check applies only to the active rule.

Using the full policy could incorrectly trigger namespace label retrieval or errors due to unrelated rules that define namespace selectors. This change avoids unnecessary lookups and aligns behavior with the current rule context.



* error check added for the generate policy



* handleUpdateRequest function signature changed to updated GetNamespaceSelectorsFromNamespaceLister



* resource generation webhook code updated with the updated signature of the GetNamespaceSelectorsFromNamespaceLister



* propagate error from namespace label lookup in buildPolicyContextFromAdmissionRequest

Updated buildPolicyContextFromAdmissionRequest to use the new GetNamespaceSelectorsFromNamespaceLister signature, which requires the policy list and returns an error if namespace retrieval fails.

This ensures that errors in fetching namespace metadata are properly surfaced during admission review processing, but only when relevant (i.e., when policies define a namespaceSelector). This improves correctness in policy evaluation and avoids silent skips of security-critical rules due to failed namespace lookups.



* policies passed in the call to buildPolicyContextFromAdmissionRequest as per the modified signature



* GetNamespaceSelectorsFromNamespaceLister call to function signature updated with the modified signature



* resource validation webhook updated with the nee signature, also the signature of buildPolicyContextFromAdmissionRequest updated to accomodate the policies in the function signature



* applied signature of the applyMutation and call to GetNamespaceSelectorsFromNamespaceLister as per the new signature



* chore(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/aws (#12695)

Bumps [github.com/sigstore/sigstore/pkg/signature/kms/aws](https://github.com/sigstore/sigstore) from 1.9.1 to 1.9.3.
- [Release notes](https://github.com/sigstore/sigstore/releases)
- [Commits](https://github.com/sigstore/sigstore/compare/v1.9.1...v1.9.3)

---
updated-dependencies:
- dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/aws dependency-version: 1.9.3 dependency-type: direct:production update-type: version-update:semver-patch ...





* align naming of ImageValidatingPolicy related code (#12703)




* Update ADOPTERS.md (#12708)

Add Tails.com to Adopters list




* chore(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/gcp (#12698)

Bumps [github.com/sigstore/sigstore/pkg/signature/kms/gcp](https://github.com/sigstore/sigstore) from 1.9.1 to 1.9.3.
- [Release notes](https://github.com/sigstore/sigstore/releases)
- [Commits](https://github.com/sigstore/sigstore/compare/v1.9.1...v1.9.3)

---
updated-dependencies:
- dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/gcp dependency-version: 1.9.3 dependency-type: direct:production update-type: version-update:semver-patch ...





* fix: add result count for VPs in the CLI (#12711)





* fix: Update Go version to fix CVE-2025-22871 vulnerability (#12714)

Update Go version from 1.23.4 to 1.23.8 to address HTTP request smuggling vulnerability (CVE-2025-22871).

Changes made:
- Updated go.mod to Go 1.23.8
- Updated GitHub Actions build setup to Go ~1.23.8
- Updated devcontainer Dockerfile to Go 1.23.8

Signed-by: Samson S. Kolge <eglok1980@gmail.com>




* feat(cli): return an error if tests are required (#12395)

* feat(cli): return an error if tests are required



* fix(docs): update flag order



---------







* chainsaw test for http (#12721)






* chore: add --noDate to cli docs command (#12712)




* fix-fail-only-flag (#12600)






* feat(helm): Add `dnsconfig` value to deployments (#12608)

* feat(helm): Add dnsConfig to deployment templates

This change allows users to customize dnsConfig for pods via values.yaml. It provides better control over DNS resolution settings.



* feat(value): Add dnsConfig to values.yaml file



* docs: Add a description for dnsConfig value



* style: Lint trailing spaces

* Delete trailing spaces to pass helm-tests actions



---------






* fix VPOL and IVPOL for Kyverno test command (#12730)




* fix: evaluate celexceptions with ivpol in CLI (#12728)




* feat: add --markdownLinks to cli docs command (#12734)




* hasNamespaceSelector is made private



* checked the namespace selector in the matchResources any and all



* test cases added for the any and all inside the match resource and exclude resource



* excludeResource nil check added and labels test cases added



---------

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
